### PR TITLE
redhat dependencies cannot be found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,54 @@
       <module>exo.core.component.web.css</module>
    </modules>
 
+   <repositories>
+	  <repository>
+	        <id>jboss-public-repository-group</id>
+			<name>JBoss Public Maven Repository Group</name>
+			<url>https://repository.jboss.org/nexus/content/groups/public-jboss/
+            </url>
+			<layout>default</layout>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</snapshots>
+	  </repository>
+	  <repository>
+			<id>redhat-all-public-repository-group</id>
+			<name>Redhat All Public Maven Repository Group</name>
+			<url>http://maven.repository.redhat.com/techpreview/all/
+            </url>
+			<layout>default</layout>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</snapshots>
+	  </repository>
+	  <repository>
+			<id>redhat-early-public-repository-group</id>
+			<name>Redhat Early Public Maven Repository Group</name>
+			<url>https://maven.repository.redhat.com/nexus/content/groups/product-earlyaccess/
+            </url>
+			<layout>default</layout>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</snapshots>
+	  </repository>
+   </repositories>
+    
    <dependencyManagement>
       <dependencies>
          <dependency>


### PR DESCRIPTION
Redhat dependencies cannot be found in the default maven repositories. You need to add the redhat public repositories to download the redhat libraries. I fixed it add the the redhat public repositories to the pom.xml