### PR TITLE
Listener not extensible

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/NewUserEventListener.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/NewUserEventListener.java
@@ -81,7 +81,7 @@ public class NewUserEventListener extends UserEventListener
    {
    }
 
-   private void createDefaultUserMemberships(User user, OrganizationService service) throws Exception
+   protected void createDefaultUserMemberships(User user, OrganizationService service) throws Exception
    {
       List<?> groups = config_.getGroup();
       if (groups.size() == 0)
@@ -93,5 +93,9 @@ public class NewUserEventListener extends UserEventListener
          MembershipType mtype = service.getMembershipTypeHandler().findMembershipType(jgroup.getMembership());
          service.getMembershipHandler().linkMembership(user, group, mtype, false);
       }
+   }
+   
+   protected NewUserConfig getConfig() {
+      return config_
    }
 }


### PR DESCRIPTION
The NewUserEventListener could be inherited in many cases. A minimum of flexibility is important in listeners. I opened the inheritance for listeners sub classes making protected the createDefaultUserMemberships method and adding a getConfig() method to import the configuration in the sub classes