### PR TITLE
removing the deprecated methods in the NewUserEventListener

### DIFF
--- a/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/NewUserEventListener.java
+++ b/exo.core.component.organization.api/src/main/java/org/exoplatform/services/organization/impl/NewUserEventListener.java
@@ -62,8 +62,7 @@ public class NewUserEventListener extends UserEventListener
       ExoContainer pcontainer = ExoContainerContext.getCurrentContainer();
       OrganizationService service =
          (OrganizationService)pcontainer.getComponentInstanceOfType(OrganizationService.class);
-      UserProfile up = service.getUserProfileHandler().createUserProfileInstance();
-      up.setUserName(user.getUserName());
+      UserProfile up = service.getUserProfileHandler().createUserProfileInstance(user.getUserName());
       service.getUserProfileHandler().saveUserProfile(up, false);
       if (config_ == null)
          return;


### PR DESCRIPTION
the setUserName(...) method is deprecated in the UserProfile. I change it using the parameter in the constructor to set the userName